### PR TITLE
クイズを編集するとクイズ実行履歴の整合性が取れなくなるため修正。

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [インフラ構成図]: https://user-images.githubusercontent.com/81066421/127653180-42854273-0623-4aa8-8bb0-219093a9b240.png
 [画面遷移図]: https://user-images.githubusercontent.com/81066421/126887789-2d13a4eb-339a-4b8a-97ac-60841dc493ec.png
 [鍵]: https://user-images.githubusercontent.com/81066421/120003596-dd50c580-c010-11eb-9442-5542a6466dbb.png
-[ER図]: https://user-images.githubusercontent.com/81066421/126892302-3740c395-b9ed-46ec-bfae-be0cdbe8ff97.png
+[ER図]: https://user-images.githubusercontent.com/81066421/127725585-f2ce6040-d3e5-4fea-b5e9-9e8f4b8348f4.png
 [チェック]: https://user-images.githubusercontent.com/81066421/120052611-131d9a80-c061-11eb-9e86-f323d6cb2b41.png
 [外部]: https://user-images.githubusercontent.com/81066421/120052614-13b63100-c061-11eb-8b16-a679f6241f26.png
 [キー]: https://user-images.githubusercontent.com/81066421/120052616-144ec780-c061-11eb-9efc-0ab2224081ab.png
@@ -240,9 +240,9 @@ ER図は以下画像の通りです。
 |--------------|---------------|:---------------:|:-------:|:------:|:--------:|:-----------:|
 | 成績回答ID    | id            |      SERIAL     |![キー][キー]|![チェック][チェック]|![チェック][チェック]|             |
 | 成績ID        | grade_id       | BIGINT UNSIGNED |         |        |![チェック][チェック]| ![外部][外部]&nbsp;grades(id) |
-| 質問番号      | question_number | SAMLLIINT |         |        |![チェック][チェック]|       |
+| クイズアイテムID| item_id      | BIGINT UNSIGNED |         |        |![チェック][チェック]| ![外部][外部]&nbsp;items(id) |
 | 回答実績       | answer       |   VARCHAR(255)  |         |        |![チェック][チェック]|             |
-| 正解有無       | pass       |  BOOLEAN　　　　  |         |        |![チェック][チェック]|             |
+| 正解有無       | pass       |  BOOLEAN         |         |        |![チェック][チェック]|             |
 | 作成日       | created_at    |    TIMESTAMP    |         |        |          |             |
 | 更新日       | updated_at    |    TIMESTAMP    |         |        |          |             |
 

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -158,32 +158,33 @@ class HomeController extends Controller
         $answers = Cache::remember('quiz_grade_id_' . $grade->id, now()->addHours(2), function () use ($grade, $quiz) {
             $answers = [];
             $answers_table = $grade->answers()->get();
+
             $correct_rates = QuizController::getItemCorrectRate($quiz);
             $items = $quiz->items()->get();
             foreach ($items as $item) {
                 $question_num = $item->question_number;
                 $item_no = Item::NUM_STR[$question_num];
-                $answer_table = $answers_table->firstWhere('question_number', $question_num);
+                $answer_table = $answers_table->firstWhere('item_id', $item->id);
 
                 $answers[$item_no]['question'] = $item->question;
                 $answers[$item_no]['answerFormat'] = $item->format;
                 $answers[$item_no]['correct'] = $item->getCorrectStr();
-                $answers[$item_no]['pass'] = $answer_table->pass;
+                $answers[$item_no]['pass'] = optional($answer_table)->pass;
                 $answers[$item_no]['correctRate'] = $correct_rates[$question_num];
 
                 switch ($item->format) {
                     case Item::FORMAT_DESCRIPTION:
-                        $answers[$item_no]['answerText'] = $answer_table->answer;
+                        $answers[$item_no]['answerText'] = optional($answer_table)->answer;
 
                         break;
                     case Item::FORMAT_RADIO:
-                        $answers[$item_no]['answerRadio'] = (int)$answer_table->answer;
+                        $answers[$item_no]['answerRadio'] = (int)optional($answer_table)->answer;
                         $answers[$item_no]['selectItemsNum'] = $item->getChoicesNum();
                         $answers[$item_no]['selectItemText'] = $item->getChoices();
 
                         break;
                     case Item::FORMAT_CHECK:
-                        $answer_check_ary = explode(',', $answer_table->answer);
+                        $answer_check_ary = explode(',', optional($answer_table)->answer);
                         $answer_check_ary = array_map(fn($n) => (int)$n, $answer_check_ary);
 
                         $answers[$item_no]['answerCheck'] = $answer_check_ary;

--- a/app/Models/Answer.php
+++ b/app/Models/Answer.php
@@ -15,8 +15,17 @@ class Answer extends Model
      * @var array
      */
     protected $fillable = [
-        'question_number',
+        'item_id',
         'answer',
         'pass',
     ];
+
+    /**
+     * リレーションシップ - itemsテーブル
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function item()
+    {
+        return $this->belongsTo(Item::class, 'item_id', 'id', 'items');
+    }
 }

--- a/app/Models/Grade.php
+++ b/app/Models/Grade.php
@@ -98,7 +98,7 @@ class Grade extends Model
         $answers = $this->answers()->get();
         foreach ($answers as $answer) {
             if ($answer->pass) {
-                $ret[] = $answer->question_number;
+                $ret[] = $answer->item()->first()->question_number;
             }
         }
         return $ret;

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -63,7 +63,6 @@ class Item extends Model
      * @var array
      */
     protected $hidden = [
-        'id',
         'created_at',
         'updated_at'
     ];

--- a/database/migrations/2021_07_31_103915_update_answers_table.php
+++ b/database/migrations/2021_07_31_103915_update_answers_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class UpdateAnswersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('answers', function (Blueprint $table) {
+            $table->dropColumn('question_number');
+            $table->after('grade_id', function($table) {
+                $table->foreignId('item_id')->default(1)->constrained()->onDelete('cascade');
+            });
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('answers', function (Blueprint $table) {
+            $table->after('grade_id', function($table) {
+                $table->smallInteger('question_number');
+            });
+            $table->dropColumn('item_id');
+        });
+    }
+}

--- a/resources/js/Components/QuizItemForm.vue
+++ b/resources/js/Components/QuizItemForm.vue
@@ -328,6 +328,7 @@ export default {
     return {
       mdiArrowAll,
       emitData: {
+        id: this.value.id || null,
         question: this.value.question || null,
         answerFormat: this.value.answerFormat || 1,
         answerText: this.value.answerText || null,


### PR DESCRIPTION
・answersテーブルにitemsテーブルのidを外部キーとして持たせるように修正。
・itemsテーブルを修正したときに削除→作成としていたところを更新するように修正。